### PR TITLE
Refering to the correct sub-folder of build_derivs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ MODULES = modules/data_modules.f90 modules/error_handler.f90 \
 					modules/maxheap.f90 modules/utils.f90 modules/kernel_module.f90 \
 					modules/derivs_module.f90 modules/surface_fit.f90 \
 					modules/OrderPack/refsor.f90 modules/OrderPack/mrgrnk.f90 \
-					GridUtilities/build_derivs.f90 \
+					GridUtilities/build_derivs/build_derivs.f90 \
 					GridUtilities/MakeGrids.f90 \
 					GridUtilities/bldGrds2.f90
 


### PR DESCRIPTION
build_derivs folder has been created and the elevation derivatives README have been moved there.

- https://github.com/teal-waters/GridUtilities/issues/4#issue-3871652608
- https://github.com/teal-waters/GridUtilities/pull/5#issue-3876383701