### PR TITLE
fix: use correct mkl library, increase stack size on Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,16 +85,18 @@ jobs:
 
       - name: Setup env
         shell: cmd
-        # MYSYS... is so bash stops escaping some things in the linker like \Fxxxxxx and \threads
         run: |
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
           echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
-          echo MSYS2_ARG_CONV_EXCL="*">> %GITHUB_ENV% 
 
       - name: Build
         shell: cmd
-        run: make -f Makefile.win
+        # Use the full path to Chocolatey's native Windows make (GnuWin32) rather than
+        # relying on PATH resolution, which would pick up Git's MSYS2-based make first.
+        # Git's make translates /flag-style args to Windows paths (e.g. /F268435456 becomes
+        # C:\Program Files\Git\F268435456), breaking ifx linker flags like /F and /link.
+        run: C:\ProgramData\Chocolatey\bin\make.exe -f Makefile.win
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         shell: cmd
         run: |
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
-          echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\ilp64;%INCLUDE%>> %GITHUB_ENV%
+          echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,11 @@ jobs:
 
       - name: Setup env
         shell: cmd
+        # MYSYS... is so bash stops escaping some things in the linker like \Fxxxxxx and \threads
         run: |
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
           echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
-          # This is so bash stops escaping some things in the linker like \Fxxxxxx and \threads
           echo MSYS2_ARG_CONV_EXCL="*" 
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
           echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
-          echo MSYS2_ARG_CONV_EXCL="*" 
+          echo MSYS2_ARG_CONV_EXCL="*">> %GITHUB_ENV% 
 
       - name: Build
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
           echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
+          # This is so bash stops escaping some things in the linker like \Fxxxxxx and \threads
+          echo MSYS2_ARG_CONV_EXCL="*" 
 
       - name: Build
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,14 +89,11 @@ jobs:
           echo MKLROOT=C:\Miniconda\envs\test\Library>> %GITHUB_ENV%
           echo INCLUDE=C:\Miniconda\envs\test\Library\include\intel64\lp64;%INCLUDE%>> %GITHUB_ENV%
           echo LIB=C:\Miniconda\envs\test\Library\lib;%LIB%>> %GITHUB_ENV%
+          echo MSYS2_ARG_CONV_EXCL=*>> %GITHUB_ENV%
 
       - name: Build
         shell: cmd
-        # Use the full path to Chocolatey's native Windows make (GnuWin32) rather than
-        # relying on PATH resolution, which would pick up Git's MSYS2-based make first.
-        # Git's make translates /flag-style args to Windows paths (e.g. /F268435456 becomes
-        # C:\Program Files\Git\F268435456), breaking ifx linker flags like /F and /link.
-        run: C:\ProgramData\Chocolatey\bin\make.exe -f Makefile.win
+        run: make.exe -f Makefile.win
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile.win
+++ b/Makefile.win
@@ -65,20 +65,22 @@ MKL_CORE_LIBS = "$(MKLROOT)/lib/mkl_intel_lp64.lib" "$(MKLROOT)/lib/mkl_sequenti
 
 all: bldgrds.exe MakeGrids.exe build_derivs.exe
 
-LDFLAGS := /libs:static /threads
+LDFLAGS := /libs:static
 # TraceChannels in ChannelNode_Module is recursive and can recurse deeply for
 # large watersheds. Windows defaults to a 1 MB stack (vs 8 MB on Linux), so
 # we explicitly reserve 256 MB to prevent stack overflow.
+# Use /F rather than /link /STACK to avoid POSIX path translation of "link"
+# on Git bash / GitHub Actions runners.
 STACK_SIZE := 268435456
 
 bldgrds.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/bldGrds2.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o bldgrds.exe /link /STACK:$(STACK_SIZE)
+	$(FC) $(LDFLAGS) /F$(STACK_SIZE) GridUtilities/bldGrds2.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o bldgrds.exe
 
 MakeGrids.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/MakeGrids.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o MakeGrids.exe /link /STACK:$(STACK_SIZE)
+	$(FC) $(LDFLAGS) /F$(STACK_SIZE) GridUtilities/MakeGrids.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o MakeGrids.exe
 
 build_derivs.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/build_derivs.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o build_derivs.exe /link /STACK:$(STACK_SIZE)
+	$(FC) $(LDFLAGS) /F$(STACK_SIZE) GridUtilities/build_derivs.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o build_derivs.exe
 
 include deps.win.mk
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -60,20 +60,25 @@ MODULE_OBJS = $(MODULES:.f90=.obj)
 SHARED_OBJS = $(filter-out GridUtilities/%, $(MODULE_OBJS))
 
 # On Windows, MKL ships .lib files rather than .a
-MKL_LAPACK95 = "$(MKLROOT)/lib/mkl_lapack95_ilp64.lib"
+MKL_LAPACK95 = "$(MKLROOT)/lib/mkl_lapack95_lp64.lib"
+MKL_CORE_LIBS = "$(MKLROOT)/lib/mkl_intel_lp64.lib" "$(MKLROOT)/lib/mkl_sequential.lib" "$(MKLROOT)/lib/mkl_core.lib"
 
 all: bldgrds.exe MakeGrids.exe build_derivs.exe
 
-LDFLAGS := /Qmkl:sequential /libs:static
+LDFLAGS := /libs:static /threads
+# TraceChannels in ChannelNode_Module is recursive and can recurse deeply for
+# large watersheds. Windows defaults to a 1 MB stack (vs 8 MB on Linux), so
+# we explicitly reserve 256 MB to prevent stack overflow.
+STACK_SIZE := 268435456
 
 bldgrds.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/bldGrds2.obj $(MKL_LAPACK95) $(SHARED_OBJS) -o bldgrds.exe
+	$(FC) $(LDFLAGS) GridUtilities/bldGrds2.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o bldgrds.exe /link /STACK:$(STACK_SIZE)
 
 MakeGrids.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/MakeGrids.obj $(MKL_LAPACK95) $(SHARED_OBJS) -o MakeGrids.exe
+	$(FC) $(LDFLAGS) GridUtilities/MakeGrids.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o MakeGrids.exe /link /STACK:$(STACK_SIZE)
 
 build_derivs.exe: $(MODULE_OBJS) | $(MOD_OUT)
-	$(FC) $(LDFLAGS) GridUtilities/build_derivs.obj $(MKL_LAPACK95) $(SHARED_OBJS) -o build_derivs.exe
+	$(FC) $(LDFLAGS) GridUtilities/build_derivs.obj $(MKL_LAPACK95) $(MKL_CORE_LIBS) $(SHARED_OBJS) -o build_derivs.exe /link /STACK:$(STACK_SIZE)
 
 include deps.win.mk
 


### PR DESCRIPTION
bldgrds was silently crashing on Windows, I think in the same place we have previously seen stack overflow errors on linux. Regardless, this increases stack size and also uses the likely "expected" mkl libraries which use 32-bit integers rather than 64.